### PR TITLE
[Feat] 오디오 입력레벨 모니터링 매니저

### DIFF
--- a/Lvlance/Lvlance.xcodeproj/project.pbxproj
+++ b/Lvlance/Lvlance.xcodeproj/project.pbxproj
@@ -13,10 +13,15 @@
 		AF11F9EF2C57DE7F0009E685 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F9EE2C57DE7F0009E685 /* AppConfiguration.swift */; };
 		AF11F9F12C57E2300009E685 /* SystemAudioClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F9F02C57E2300009E685 /* SystemAudioClassifier.swift */; };
 		AF11F9F32C587C4D0009E685 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11F9F22C587C4D0009E685 /* AppState.swift */; };
+		AFB83FA02C5C6D2700E48896 /* AudioInputLevelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB83F9F2C5C6D2700E48896 /* AudioInputLevelManager.swift */; };
+		AFB83FA82C5C76DA00E48896 /* DetectSoundsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB83FA32C5C76DA00E48896 /* DetectSoundsView.swift */; };
+		AFB83FA92C5C76DA00E48896 /* SetupMonitoredSoundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB83FA42C5C76DA00E48896 /* SetupMonitoredSoundView.swift */; };
+		AFB83FAA2C5C76DA00E48896 /* InstrumentBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB83FA52C5C76DA00E48896 /* InstrumentBar.swift */; };
+		AFB83FAB2C5C76DA00E48896 /* SettingPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB83FA62C5C76DA00E48896 /* SettingPopoverView.swift */; };
+		AFB83FAC2C5C76DA00E48896 /* TempView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB83FA72C5C76DA00E48896 /* TempView.swift */; };
 		B57DBED52C4E78D600E8F182 /* MicSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57DBED42C4E78D600E8F182 /* MicSelectView.swift */; };
 		B57DBED72C4E78E400E8F182 /* BandSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57DBED62C4E78E400E8F182 /* BandSettingView.swift */; };
 		B57DBED92C4E78FF00E8F182 /* SideBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57DBED82C4E78FF00E8F182 /* SideBarView.swift */; };
-		B57DBEDB2C4E791000E8F182 /* PlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57DBEDA2C4E791000E8F182 /* PlayingView.swift */; };
 		B57DBEDE2C522E0900E8F182 /* Song.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57DBEDD2C522E0900E8F182 /* Song.swift */; };
 		B57DBEE22C52327500E8F182 /* Instrument.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57DBEE12C52327500E8F182 /* Instrument.swift */; };
 		B57DBEEF2C54A50E00E8F182 /* BandSong.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B57DBEED2C54A50E00E8F182 /* BandSong.xcdatamodeld */; };
@@ -43,10 +48,15 @@
 		AF11F9EE2C57DE7F0009E685 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		AF11F9F02C57E2300009E685 /* SystemAudioClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioClassifier.swift; sourceTree = "<group>"; };
 		AF11F9F22C587C4D0009E685 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		AFB83F9F2C5C6D2700E48896 /* AudioInputLevelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputLevelManager.swift; sourceTree = "<group>"; };
+		AFB83FA32C5C76DA00E48896 /* DetectSoundsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetectSoundsView.swift; sourceTree = "<group>"; };
+		AFB83FA42C5C76DA00E48896 /* SetupMonitoredSoundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetupMonitoredSoundView.swift; sourceTree = "<group>"; };
+		AFB83FA52C5C76DA00E48896 /* InstrumentBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstrumentBar.swift; sourceTree = "<group>"; };
+		AFB83FA62C5C76DA00E48896 /* SettingPopoverView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingPopoverView.swift; sourceTree = "<group>"; };
+		AFB83FA72C5C76DA00E48896 /* TempView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TempView.swift; sourceTree = "<group>"; };
 		B57DBED42C4E78D600E8F182 /* MicSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicSelectView.swift; sourceTree = "<group>"; };
 		B57DBED62C4E78E400E8F182 /* BandSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandSettingView.swift; sourceTree = "<group>"; };
 		B57DBED82C4E78FF00E8F182 /* SideBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarView.swift; sourceTree = "<group>"; };
-		B57DBEDA2C4E791000E8F182 /* PlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayingView.swift; sourceTree = "<group>"; };
 		B57DBEDD2C522E0900E8F182 /* Song.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Song.swift; sourceTree = "<group>"; };
 		B57DBEE12C52327500E8F182 /* Instrument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Instrument.swift; sourceTree = "<group>"; };
 		B57DBEEE2C54A50E00E8F182 /* BandSong.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = BandSong.xcdatamodel; sourceTree = "<group>"; };
@@ -148,7 +158,11 @@
 		B57DBED12C4E4CED00E8F182 /* Playing */ = {
 			isa = PBXGroup;
 			children = (
-				B57DBEDA2C4E791000E8F182 /* PlayingView.swift */,
+				AFB83FA32C5C76DA00E48896 /* DetectSoundsView.swift */,
+				AFB83FA52C5C76DA00E48896 /* InstrumentBar.swift */,
+				AFB83FA62C5C76DA00E48896 /* SettingPopoverView.swift */,
+				AFB83FA42C5C76DA00E48896 /* SetupMonitoredSoundView.swift */,
+				AFB83FA72C5C76DA00E48896 /* TempView.swift */,
 			);
 			path = Playing;
 			sourceTree = "<group>";
@@ -254,6 +268,7 @@
 			children = (
 				C7D8AC962C5B890E001AB123 /* Model */,
 				C7D8AC972C5B890E001AB123 /* AudioManager.swift */,
+				AFB83F9F2C5C6D2700E48896 /* AudioInputLevelManager.swift */,
 			);
 			path = AudioManaging;
 			sourceTree = "<group>";
@@ -328,15 +343,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AFB83FA02C5C6D2700E48896 /* AudioInputLevelManager.swift in Sources */,
 				C73C83832C5A297C001B7540 /* OnboardingNextView.swift in Sources */,
 				AF11F9E92C57CC850009E685 /* SoundIdentifier.swift in Sources */,
 				C7D8AC9A2C5B890E001AB123 /* AudioManager.swift in Sources */,
+				AFB83FAA2C5C76DA00E48896 /* InstrumentBar.swift in Sources */,
 				C73C83852C5A299B001B7540 /* OnboardingStartView.swift in Sources */,
 				B5A9F6362C5BB65F00EFD035 /* InstrumentEntity+CoreDataClass.swift in Sources */,
 				B5A9F6372C5BB65F00EFD035 /* InstrumentEntity+CoreDataProperties.swift in Sources */,
 				B5A9F6382C5BB65F00EFD035 /* SongEntity+CoreDataClass.swift in Sources */,
 				B5A9F6392C5BB65F00EFD035 /* SongEntity+CoreDataProperties.swift in Sources */,
 				C7D8AC992C5B890E001AB123 /* Device.swift in Sources */,
+				AFB83FAB2C5C76DA00E48896 /* SettingPopoverView.swift in Sources */,
+				AFB83FAC2C5C76DA00E48896 /* TempView.swift in Sources */,
 				AF11F9F12C57E2300009E685 /* SystemAudioClassifier.swift in Sources */,
 				B57DBEDE2C522E0900E8F182 /* Song.swift in Sources */,
 				C73C83812C5A292A001B7540 /* OnboardingView.swift in Sources */,
@@ -344,15 +363,16 @@
 				B57DBED52C4E78D600E8F182 /* MicSelectView.swift in Sources */,
 				B59724B62C4909CD0027990A /* ContentView.swift in Sources */,
 				B57DBED72C4E78E400E8F182 /* BandSettingView.swift in Sources */,
+				AFB83FA82C5C76DA00E48896 /* DetectSoundsView.swift in Sources */,
 				B57DBEE22C52327500E8F182 /* Instrument.swift in Sources */,
 				AF11F9EF2C57DE7F0009E685 /* AppConfiguration.swift in Sources */,
-				B57DBEDB2C4E791000E8F182 /* PlayingView.swift in Sources */,
 				AF11F9F32C587C4D0009E685 /* AppState.swift in Sources */,
 				AF11F9EB2C57D1550009E685 /* DetectionState.swift in Sources */,
 				B57DBED92C4E78FF00E8F182 /* SideBarView.swift in Sources */,
 				AF11F9ED2C57D5BD0009E685 /* ClassificationResultsSubject.swift in Sources */,
 				B59724B42C4909CD0027990A /* LvlanceApp.swift in Sources */,
 				B57DBF022C54D5A500E8F182 /* CoreDataManager.swift in Sources */,
+				AFB83FA92C5C76DA00E48896 /* SetupMonitoredSoundView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -487,7 +507,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Lvlance/Preview Content\"";
-				DEVELOPMENT_TEAM = PAPTDHH68K;
+				DEVELOPMENT_TEAM = ZWTS2P7AH7;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -514,7 +534,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Lvlance/Preview Content\"";
-				DEVELOPMENT_TEAM = PAPTDHH68K;
+				DEVELOPMENT_TEAM = ZWTS2P7AH7;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Lvlance/Lvlance/Manager/AudioManaging/AudioInputLevelManager.swift
+++ b/Lvlance/Lvlance/Manager/AudioManaging/AudioInputLevelManager.swift
@@ -1,0 +1,117 @@
+//
+//  AudioInputLevelManager.swift
+//  Lvlance
+//
+//  Created by 이종선 on 8/2/24.
+//
+
+import SwiftUI
+import Combine
+import CoreAudio
+import AudioToolbox
+
+
+class AudioInputLevelManager: ObservableObject {
+    
+    @Published private(set) var currentAudioLevel: Float = 0.0
+    private var audioQueue: AudioQueueRef?
+
+    func startMonitoring() {
+        stopMonitoring()
+        
+        var dataFormat = AudioStreamBasicDescription(
+            mSampleRate: 44100.0,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked,
+            mBytesPerPacket: 2,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 2,
+            mChannelsPerFrame: 1,
+            mBitsPerChannel: 16,
+            mReserved: 0
+        )
+        
+        var audioQueue: AudioQueueRef?
+        var error = AudioQueueNewInput(
+            &dataFormat,
+            audioQueueInputCallback,
+            Unmanaged.passUnretained(self).toOpaque(),
+            nil,
+            nil,
+            0,
+            &audioQueue
+        )
+        
+        guard error == noErr, let queue = audioQueue else {
+            print("Error creating audio queue: \(error)")
+            return
+        }
+        
+        self.audioQueue = queue
+        
+        var enabledLevelMeter: UInt32 = 1
+        AudioQueueSetProperty(queue, kAudioQueueProperty_EnableLevelMetering, &enabledLevelMeter, UInt32(MemoryLayout<UInt32>.size))
+        
+        let bufferByteSize: UInt32 = 512
+        
+        for _ in 0..<3 {
+            var buffer: AudioQueueBufferRef?
+            error = AudioQueueAllocateBuffer(queue, bufferByteSize, &buffer)
+            if let buffer = buffer {
+                AudioQueueEnqueueBuffer(queue, buffer, 0, nil)
+            }
+        }
+        
+        error = AudioQueueStart(queue, nil)
+        if error != noErr {
+            print("Error starting audio queue: \(error)")
+            return
+        }
+    }
+
+    func stopMonitoring() {
+        if let queue = audioQueue {
+            AudioQueueStop(queue, true)
+            AudioQueueDispose(queue, true)
+            audioQueue = nil
+        }
+    }
+
+    func updateAudioLevel() {
+        guard let queue = audioQueue else { return }
+        
+        var levelMeter = AudioQueueLevelMeterState()
+        var propertySize = UInt32(MemoryLayout<AudioQueueLevelMeterState>.size)
+        
+        let error = AudioQueueGetProperty(queue, kAudioQueueProperty_CurrentLevelMeterDB, &levelMeter, &propertySize)
+        
+        if error == noErr {
+            let level = levelMeter.mAveragePower
+            let normalizedLevel = (level + 50) / 50
+            let clampedLevel = max(0, min(normalizedLevel, 1)) 
+            DispatchQueue.main.async {
+                self.currentAudioLevel = clampedLevel
+            }
+        } else {
+            print("Error getting audio level: \(error)")
+        }
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+}
+
+func audioQueueInputCallback(
+    _ inUserData: UnsafeMutableRawPointer?,
+    _ inAQ: AudioQueueRef,
+    _ inBuffer: AudioQueueBufferRef,
+    _ inStartTime: UnsafePointer<AudioTimeStamp>,
+    _ inNumberPacketDescriptions: UInt32,
+    _ inPacketDescs: UnsafePointer<AudioStreamPacketDescription>?
+) {
+    guard let inUserData = inUserData else { return }
+    let audioInputManager = Unmanaged<AudioInputLevelManager>.fromOpaque(inUserData).takeUnretainedValue()
+    audioInputManager.updateAudioLevel()
+    AudioQueueEnqueueBuffer(inAQ, inBuffer, 0, nil)
+}


### PR DESCRIPTION
-  현재 선택된 기기로 입력되는 소리의 레벨을 보여줄 수 있습니다.

## 🔥 작업한 내용
```swift
class AudioInputManager: ObservableObject {
    @Published private(set) var currentAudioLevel: Float = 0.0
    private var audioQueue: AudioQueueRef?
```
- currentAudioLevel : 현재 입력되고 있는 AudioLevel을 발행해 View에서 표시할 수 있도록 합니다. 
- audioQueue : CoreAudio의 AudioQueue에 대한 참조를 저장해 이를 통해 오디오 입력을 관리할 수 있습니다. 

```swift
func startMonitoring() {

    stopMonitoring()
    
    var dataFormat = AudioStreamBasicDescription( ... )

var audioQueue: AudioQueueRef?
    var error = AudioQueueNewInput( ...  )
... 
    self.audioQueue = queue
```
- `stopMonitoring( )` :  기존 모니터링을 중지하여 새로운 모니터링을 시작하기전 리소스를 정리합니다. 
- `AudioStreamBasicDescription` : AudioStream의 Format을 정의합니다. 
- `AudioQueueNewInput` : 새로운 오디오 입력큐를 정의, 입력큐에서는 오디오 형식, 오디오 도착시 콜백 함수, 콜백에서 사용할 사용자 데이터를 전달
- `self.audioQueue = queue` : 새로 만든 queue를 저장 프로퍼티에 저장해서 이를 참조해 오디오 입력을 관리할 수 있도록 함. 

```swift
var enabledLevelMeter: UInt32 = 1
    AudioQueueSetProperty(queue, kAudioQueueProperty_EnableLevelMetering, &enabledLevelMeter, UInt32(MemoryLayout<UInt32>.size))
```
- `AudioQueueSetProperty`: 오디오 큐의 속성을 설정합니다.
- `kAudioQueueProperty_EnableLevelMetering`: 레벨 미터링을 활성화하는 속성
- `&enabledLevelMeter: 활성화 값` (1 = 활성화)

```swift
error = AudioQueueStart(queue, nil)
    if error != noErr {
        print("Error starting audio queue: \(error)")
        return
    }
```
- `AudioQueueStart(queue, nil)`: 앞서 설정한 오디오 큐를 시작 

- `stopMonitoring` : 오디오 큐 중지 및 해당 오디오 큐와 관련된 모든 리소스를 해제 

```swift
func updateAudioLevel() {
    guard let queue = audioQueue else { return }
    
    var levelMeter = AudioQueueLevelMeterState()
    var propertySize = UInt32(MemoryLayout<AudioQueueLevelMeterState>.size)
    let error = AudioQueueGetProperty( ... )
    
    if error == noErr {
        let level = levelMeter.mAveragePower
        let normalizedLevel = (level + 50) / 50 
        let clampedLevel = max(0, min(normalizedLevel, 1))
        DispatchQueue.main.async {
            self.currentAudioLevel = clampedLevel
        }
}
```
- `AudioQueueGetProperty`: 오디오 큐의 현재 레벨 미터 상태를 가져옵니다.
- `levelMeter.mAveragePower`: 현재 오디오 레벨의 평균 파워 (dB 단위)
- 정규화: dB 값을 0~1 사이의 값으로 변환합니다. -50dB을 최소값으로 가정하고 있습니다.
- `DispatchQueue.main.async`: UI 업데이트는 메인 스레드에서 수행해야 하므로 사용합니다.

```swift
func audioQueueInputCallback( ... ) {
    guard let inUserData = inUserData else { return }
 ...
}
```
- callback 함수 : 시스템 입력 장치로부터 새로운 오디오 데이터가 도착할때마다 Core Audio에 의해 호출 
- 오디오 레벨을 업데이트하고 사용한 버퍼를 다시 큐에 추가해 해당 버퍼에 다시 오디오 데이터를 담을 수 있도록 함

## ⭐️ PR Point
- `AudioInputLevelManager`를 `AudioManager`와 분리한 이유는 사용할 오디오 장치에 대한 관리와 이미 설정된 오디오 장치로부터 입력되고 있는 오디오의 레벨을 모니터링하는 것을 격리함으로써 각 매니저의 역할을 확실히 하기 위함입니다. 
- CoreAudio 의 메서드에서 사용되는`&`는 메모리 주소를 직접 전달하기 위한 키워드로써 swift의 inout 키워드와 동일한 역할을 합니다. 해당 키워드를 통해 메서드에 인자로 전달한 변수를 직접 변경할수 있게 합니다. 
- CoreAudio와 같은 C 기반 API의 경우에 메모리 주소 전달 방식을 통해 호환성을 유지합니다. 
- 따라서 `&` 키워드 사용시, 전달한 변수의 메서드에 의한 변경 가능성을 인지해야합니다.  

## 🚨 관련 이슈
- close: #27
