### PR TITLE
[Feat] PopOverView 마이크 입력 레벨 표시 및 마이크 선택 기능 추가 

### DIFF
--- a/Lvlance/Lvlance/Views/Playing/SettingPopoverView.swift
+++ b/Lvlance/Lvlance/Views/Playing/SettingPopoverView.swift
@@ -11,7 +11,13 @@ struct SettingPopoverView: View {
     @State private var inputLevel: Double = 0.5
     @State private var isExpanded = false
     
+    //  BandSettingView에서 초기화해서 받아와야함
+    @StateObject var audioManager = AudioManager()
+    @StateObject var audioInputLevelManager = AudioInputLevelManager()
+    
+    
     var body: some View {
+        
         VStack(alignment: .leading, spacing: 20) {
             Text("입력 레벨")
                 .font(.headline)
@@ -20,36 +26,56 @@ struct SettingPopoverView: View {
                 .foregroundColor(.secondary)
             
             HStack(spacing: 2) {
-                ForEach(0..<30, id: \.self) { _ in
+                ForEach(0..<30, id: \.self) { index in
                     Rectangle()
-                        .fill(Color.white.opacity(0.5))
+                        .fill(Color.white.opacity(index < Int(audioInputLevelManager.currentAudioLevel * 30) ? 1.0 : 0.5))
                         .frame(width: 5, height: 20)
                 }
             }
             
-            Slider(value: $inputLevel, in: 0...1)
-                .accentColor(.white)
+            Slider(value: $audioManager.selectedAudioDevice.currentGain, in: audioManager.selectedAudioDevice.minGain...audioManager.selectedAudioDevice.maxGain) { _ in
+                audioManager.setGain(audioManager.selectedAudioDevice.currentGain, for: audioManager.selectedAudioDevice)
+            }
+            .accentColor(.white)
+            .disabled(!audioManager.selectedAudioDevice.hasGainControl)
             
             DisclosureGroup(
                 isExpanded: $isExpanded,
                 content: {
-                    VStack(alignment: .leading) {
-                        ForEach(0..<8) { _ in
-                            Text("Same as system (MacBook Pro Mic)")
-                                .frame(height: 10)
-                                .foregroundColor(.blue)
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 10) {
+                            ForEach(audioManager.audioDevices, id: \.id) { device in
+                                Text(device.name)
+                                    .foregroundColor(device.id == audioManager.selectedAudioDevice.id ? .systemPurple : .white)
+                                    .onTapGesture {
+                                        audioManager.selectDevice(device)
+                                    }
+                            }
                         }
+                        .frame(maxHeight: 200) // 최대 높이 제한
                     }
-                    .padding(.vertical)
+                    .padding(.vertical, 5)
                 },
                 label: {
                     Text("입력 기기 선택하기")
                         .foregroundColor(.white)
                 }
             )
+            
         }
+        .animation(.easeInOut, value: isExpanded)
         .padding()
         .foregroundColor(.white)
+        .onAppear {
+            audioInputLevelManager.startMonitoring()
+            Task {
+                await audioManager.start()
+                print("Audio devices: \(audioManager.audioDevices)") // 디버깅용
+            }
+        }
+        .onDisappear {
+            audioInputLevelManager.stopMonitoring()
+        }
     }
 }
 


### PR DESCRIPTION
## 🔥 작업한 내용
- PlayView 내부의 PopoverView에서 현재 선택 마이크를 변경할 수 있습니다.
- Popoverview에서 현재 입력되고 있는 음량을 표시할 수 있습니다.

## ⭐️ PR Point
- 현재 @StateObject로 선언되어 있는 AudioManager는 BandSettingView로 옮기고 PopOverView에서 EnviornmentObject로 받아서 전체 app에서 동일한 마이크 선택 기능을 이용하도록 합니다. 

## 🚨 관련 이슈
- close: #32

