### PR TITLE
[Fix] 새로운 곡 추가시, 리스트 선택 버벅임 현상 개선 

### DIFF
--- a/Lvlance/Lvlance/Views/BandSetting/SideBar/SideBarView.swift
+++ b/Lvlance/Lvlance/Views/BandSetting/SideBar/SideBarView.swift
@@ -57,7 +57,7 @@ struct SideBarView: View {
                                     .foregroundStyle(.systemPurple)
                             }
                         }
-                        .frame(maxWidth: .infinity)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         .contentShape(Rectangle())
                         .onTapGesture {
                             songViewModel.selectedSong = song

--- a/Lvlance/Lvlance/Views/BandSetting/SideBar/SideBarView.swift
+++ b/Lvlance/Lvlance/Views/BandSetting/SideBar/SideBarView.swift
@@ -57,6 +57,8 @@ struct SideBarView: View {
                                     .foregroundStyle(.systemPurple)
                             }
                         }
+                        .frame(maxWidth: .infinity)
+                        .contentShape(Rectangle())
                         .onTapGesture {
                             songViewModel.selectedSong = song
                         }

--- a/Lvlance/Lvlance/Views/BandSetting/SongViewModel.swift
+++ b/Lvlance/Lvlance/Views/BandSetting/SongViewModel.swift
@@ -18,8 +18,15 @@ class SongViewModel: ObservableObject {
     }
     
     func setupSongs() {
-        songs = coreDataManager.getAllSongs()
-        selectedSong = songs.first
+        DispatchQueue.global(qos: .userInitiated).async {
+            let fetchedSongs = self.coreDataManager.getAllSongs()
+            DispatchQueue.main.async {
+                self.songs = fetchedSongs
+                if self.selectedSong == nil {
+                    self.selectedSong = fetchedSongs.first
+                }
+            }
+        }
     }
     
     func createSong(selectedInstruments: [Instrument]) {


### PR DESCRIPTION
## 🔥 작업한 내용

### SideBar ListRow Touch 영역 확장 
#### 기존 영역
![image](https://github.com/user-attachments/assets/7706cf4e-68c3-4d3e-bf94-d5a09df0c4e6)
#### 변경된 영역 
![image](https://github.com/user-attachments/assets/c54498cc-c5e5-4df5-a474-d2b528a08497)
- `Background(Rectangle().fill(.white)`를 사용하여 해당 컴포넌트가 화면상에 차지하고 있는 영역을 알 수 있습니다. 
- `contentShape`을 사용해서 터치 가능영역을 지정할 수 있습니다. 
- SwiftUI에서의 각 컨텐츠의 터치 가능영역은 기본적으로 해당 컨텐츠의 시각적 영역으로 제한됩니다. 따라서 텍스트를 사용할 경우, 텍스트상에서만 터치가 가능합니다. 
- `frame()`을 사용하면 컨텐츠 영역이외에도 추가적인 영역을 부여하여 `contentShape`을 통해 터치 가능영역을 지정할 수 있습니다. 

### `SongViewModel`의 `setupSongs( )` 메서드 비동기 호출 
- `createSong( )` 에서 `createSongEntity( )`를 비동기로 호출하여 해당 작업이 백그라운 쓰레드에서 실행되어도 이 작업이 완료된후 `setupSongs( )`가 메인쓰레드에서 호출되고 있습니다. 따라서 `getAllSongs()`이 메인쓰레드에서 호출되고 있습니다. 해당 작업은 DB에 저장된 모든 엔티티를 조회하므로 UI 업데이트에 지장을 줄 수 있습니다. 
- 따라서 `setupSongs()` 내부의 `getAllSongs` 또한 백그라운드에서 호출해주고 해당 호출 결과만 메인쓰레드에 반영해주는 방식을 취해야만 `createSong( )`이 정상적으로 비동기 호출이 가능합니다. 

## ⭐️ PR Point
- 현재 `createSong( )`호출시 새로운 엔티티의 저장이 완료된 후 DB로 부터 모든 엔티티를 다시 조회하는 방식을 취하고 있어 실제 필요한 것보다 무거운 작업을 호출합니다. 
- 따라서 coreDataManager에 `fetchLatestSong( )`과 같이 DB로 부터 가장 최신 엔티티 하나만 조회하는 메서드를 만들어 `createSong()` 내부에서는 해당 메서드를 통해 가장 최근에 만들어진 엔티티 "하나"만 조회하여 최적화가 가능할 것 같습니다. 

## 🚨 관련 이슈
- Resolved: #44 
