### PR TITLE
[Fix] 노래 추가, 삭제 시 뷰에 반영 안되던 문제 해결

### DIFF
--- a/Lvlance/Lvlance/Manager/CoreDataManager.swift
+++ b/Lvlance/Lvlance/Manager/CoreDataManager.swift
@@ -76,6 +76,7 @@ class CoreDataManager {
         
         for instrument in instruments {
             let newInstrument = InstrumentEntity(context: context)
+            newInstrument.instrumentId = instrument.id
             newInstrument.type = instrument.type.rawValue
             newSong.addToInstruments(newInstrument)
         }

--- a/Lvlance/Lvlance/Views/BandSetting/SideBar/InstrumentAdd/InstrumentAddingView.swift
+++ b/Lvlance/Lvlance/Views/BandSetting/SideBar/InstrumentAdd/InstrumentAddingView.swift
@@ -48,7 +48,8 @@ struct InstrumentAddingView: View {
                             songViewModel.updateInstrument(song: selectedSong, selectedInstruments: selectedInstrumentsType.map{ Instrument(type: $0) })
                         }
                     } else {
-                        songViewModel.createSong(selectedInstruments: selectedInstrumentsType.map{ Instrument(type: $0) })
+                        songViewModel.createSong(selectedInstruments: selectedInstrumentsType.map { Instrument(type: $0) })
+                        songViewModel.setupSongs()
                     }
                     isSheetPresented = false
                 } label: {

--- a/Lvlance/Lvlance/Views/BandSetting/SideBar/SideBarView.swift
+++ b/Lvlance/Lvlance/Views/BandSetting/SideBar/SideBarView.swift
@@ -21,6 +21,10 @@ struct SideBarView: View {
     @State private var editingSongId: UUID?
     @State private var editingTitle: String = ""
     
+    private var isNoSongSelected: Bool {
+            songViewModel.selectedSong == nil
+        }
+    
     var body: some View {
         VStack(alignment: .trailing ,spacing: 0) {
             Spacer().frame(height: 46)
@@ -36,10 +40,16 @@ struct SideBarView: View {
                 appState.restartDetection(config: appConfig) // 재생시키기
                 path.append("playView")
             } label: {
-                Image(systemName: "play.fill")
+                if isNoSongSelected {
+                    Image(systemName: "play.fill")
+                        .foregroundStyle(.gray)
+                } else {
+                    Image(systemName: "play.fill")
+                }
             }
             .help("재생 버튼을 눌러 연주를 시작하세요")
-            .buttonStyle(playButtonStyle())            
+            .buttonStyle(playButtonStyle()) 
+            .disabled(isNoSongSelected)
             
             Spacer().frame(height: 20)
             

--- a/Lvlance/Lvlance/Views/BandSetting/SongViewModel.swift
+++ b/Lvlance/Lvlance/Views/BandSetting/SongViewModel.swift
@@ -12,7 +12,7 @@ class SongViewModel: ObservableObject {
     
     @Published var songs: [Song] = []
     @Published var selectedSong: Song? = nil
-        
+    
     init() {
         self.setupSongs()
     }
@@ -22,9 +22,7 @@ class SongViewModel: ObservableObject {
             let fetchedSongs = self.coreDataManager.getAllSongs()
             DispatchQueue.main.async {
                 self.songs = fetchedSongs
-                if self.selectedSong == nil {
-                    self.selectedSong = fetchedSongs.first
-                }
+                self.selectedSong = fetchedSongs.first               
             }
         }
     }
@@ -32,7 +30,7 @@ class SongViewModel: ObservableObject {
     func createSong(selectedInstruments: [Instrument]) {
         DispatchQueue.global(qos: .userInitiated).async {
             self.coreDataManager.createSongEntity(instruments: selectedInstruments)
-
+            
             DispatchQueue.main.async {
                 self.setupSongs()
             }


### PR DESCRIPTION
## 🔥 작업한 내용
- 곡이 없을 때 재생버튼 비활성화하도록 해주었습니다
- 새로운 곡을 추가하거나 기존 곡을 삭제했을때 화면에 바로 반영이 안되던 문제해결했습니다


## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 놀랍게도 악기의 id값을 entity에 같이 저장해주지 않아서 정말 coredata에 저장이 안되고 있었다는 사실... 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #59 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
