### PR TITLE
[Chore] 연주뷰에 현재 선택된 곡명 추가 

### DIFF
--- a/Lvlance/Lvlance/Localizable.xcstrings
+++ b/Lvlance/Lvlance/Localizable.xcstrings
@@ -139,7 +139,11 @@
         }
       }
     },
+    "곡 제목" : {
+
+    },
     "곡 제목 / " : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Lvlance/Lvlance/Views/BandSetting/BandSettingView.swift
+++ b/Lvlance/Lvlance/Views/BandSetting/BandSettingView.swift
@@ -41,7 +41,7 @@ struct BandSettingView: View {
             }
             .navigationDestination(for: String.self) { string in
                 if string == "playView" {
-                    DetectSoundsView(state: appState, config: $appConfig, path: $path)
+                    DetectSoundsView(state: appState, config: $appConfig, path: $path, songTitle: songViewModel.selectedSong?.title ?? "")
                 }
             }
         }

--- a/Lvlance/Lvlance/Views/BandSetting/SongViewModel.swift
+++ b/Lvlance/Lvlance/Views/BandSetting/SongViewModel.swift
@@ -52,6 +52,9 @@ class SongViewModel: ObservableObject {
     func updateSongTitle(song: Song, newTitle: String) {
         if let index = songs.firstIndex(where: { $0.id == song.id }) {
             songs[index].title = newTitle
+            if song.id == selectedSong?.id {
+                selectedSong?.title = newTitle
+            }
             coreDataManager.updateSongEntity(song: song, title: newTitle)
         }
     }

--- a/Lvlance/Lvlance/Views/Playing/DetectSoundsView.swift
+++ b/Lvlance/Lvlance/Views/Playing/DetectSoundsView.swift
@@ -16,6 +16,7 @@ struct DetectSoundsView: View {
     @Binding var config: AppConfiguration
     @Binding var path: NavigationPath
     @State private var isLoading = false
+    var songTitle: String 
     
     static func generateMeter(confidence: Double, width: CGFloat, height: CGFloat, varientSize: Double) -> some View {
         GeometryReader { geometry in
@@ -82,6 +83,13 @@ struct DetectSoundsView: View {
                         }
                     }
                 }
+        }
+        .overlay(alignment: .topLeading){
+            Text(songTitle)
+                .font(.system(size: 18))
+                .fontWeight(.semibold)
+                .padding(.leading, 60)
+                .padding(.top, 60)
         }
     }
 }

--- a/Lvlance/Lvlance/Views/Playing/DetectSoundsView.swift
+++ b/Lvlance/Lvlance/Views/Playing/DetectSoundsView.swift
@@ -63,8 +63,6 @@ struct DetectSoundsView: View {
                 
             }
         }
-        
-        
         .overlay(alignment: .bottomLeading){
             Image(systemName: "gearshape")
                 .font(.system(size: 30))
@@ -84,22 +82,6 @@ struct DetectSoundsView: View {
                         }
                     }
                 }
-        }
-        .ignoresSafeArea(.all)
-        .navigationBarBackButtonHidden(true)
-        .toolbar{
-            ToolbarItem(placement: .navigation) {
-                HStack{
-                    Image(systemName: "chevron.left")
-                    Text("곡 제목 / ")
-                }
-                .font(.title2)
-                .fontWeight(.regular)
-                .padding(.vertical)
-                .onTapGesture {
-                    path.removeLast()
-                }
-            }
         }
     }
 }

--- a/Lvlance/Lvlance/Views/Playing/SetupMonitoredSoundView.swift
+++ b/Lvlance/Lvlance/Views/Playing/SetupMonitoredSoundView.swift
@@ -4,87 +4,87 @@
 //
 //  Created by 이종선 on 7/30/24.
 //
-import SwiftUI
-
-
-enum AppRoute: Hashable {
-    case detectSounds
-}
-
-// 여기서 이미 설정되어있는 값을 받아 수정 가능하게 해줌
-struct SetupMonitoredSoundsView: View {
-    
-    @ObservedObject var appState: AppState
-    @Binding var appConfig: AppConfiguration
-    
-    // 현재 설정 중인 변경사항을 저장
-    @State private var selectedInstruments: Set<InstrumentType> = []
-    @State private var navigationPath = NavigationPath()
-    
-    var body: some View {
-        NavigationStack(path: $navigationPath) {
-            VStack {
-                Text("탐지할 악기 선택").font(.title).padding()
-                
-                HStack {
-                    ForEach(InstrumentType.allCases, id: \.self) { instrument in
-                        Button(action: {
-                            toggleSelection(instrument)
-                        }) {
-                            VStack {
-                                Image(instrument.maskImage)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 100, height: 100)
-                                Text(instrument.title)
-                                Spacer()
-                                if selectedInstruments.contains(instrument) {
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .foregroundColor(.blue)
-                                } else {
-                                    Image(systemName: "circle")
-                                        .foregroundColor(.gray)
-                                }
-                            }
-                        }
-                    }
-                }
-                
-                Button(action: {
-                    updateSelectedSounds()
-                    appState.restartDetection(config: appConfig)
-                    navigationPath.append(AppRoute.detectSounds)
-                }) {
-                    Text("완료")
-                        .padding()
-                        .background(Color.blue)
-                        .foregroundColor(.white)
-                        .cornerRadius(10)
-                }
-            }
-            .onAppear(perform: initializeSelectedInstruments)
-            .navigationDestination(for: AppRoute.self) { route in
-                switch route {
-                case .detectSounds:
-                    DetectSoundsView(state: appState, config: $appConfig, path: $navigationPath)
-                }
-            }
-        }
-    }
-    
-    private func toggleSelection(_ instrument: InstrumentType) {
-        if selectedInstruments.contains(instrument) {
-            selectedInstruments.remove(instrument)
-        } else {
-            selectedInstruments.insert(instrument)
-        }
-    }
-    
-    private func updateSelectedSounds() {
-        appConfig.monitoredSounds = Set(selectedInstruments.map { SoundIdentifier(instrument: $0) })
-    }
-    
-    private func initializeSelectedInstruments() {
-        selectedInstruments = Set(appConfig.monitoredSounds.map { $0.instrument })
-    }
-}
+//import SwiftUI
+//
+//
+//enum AppRoute: Hashable {
+//    case detectSounds
+//}
+//
+//// 여기서 이미 설정되어있는 값을 받아 수정 가능하게 해줌
+//struct SetupMonitoredSoundsView: View {
+//    
+//    @ObservedObject var appState: AppState
+//    @Binding var appConfig: AppConfiguration
+//    
+//    // 현재 설정 중인 변경사항을 저장
+//    @State private var selectedInstruments: Set<InstrumentType> = []
+//    @State private var navigationPath = NavigationPath()
+//    
+//    var body: some View {
+//        NavigationStack(path: $navigationPath) {
+//            VStack {
+//                Text("탐지할 악기 선택").font(.title).padding()
+//                
+//                HStack {
+//                    ForEach(InstrumentType.allCases, id: \.self) { instrument in
+//                        Button(action: {
+//                            toggleSelection(instrument)
+//                        }) {
+//                            VStack {
+//                                Image(instrument.maskImage)
+//                                    .resizable()
+//                                    .scaledToFit()
+//                                    .frame(width: 100, height: 100)
+//                                Text(instrument.title)
+//                                Spacer()
+//                                if selectedInstruments.contains(instrument) {
+//                                    Image(systemName: "checkmark.circle.fill")
+//                                        .foregroundColor(.blue)
+//                                } else {
+//                                    Image(systemName: "circle")
+//                                        .foregroundColor(.gray)
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//                
+//                Button(action: {
+//                    updateSelectedSounds()
+//                    appState.restartDetection(config: appConfig)
+//                    navigationPath.append(AppRoute.detectSounds)
+//                }) {
+//                    Text("완료")
+//                        .padding()
+//                        .background(Color.blue)
+//                        .foregroundColor(.white)
+//                        .cornerRadius(10)
+//                }
+//            }
+//            .onAppear(perform: initializeSelectedInstruments)
+//            .navigationDestination(for: AppRoute.self) { route in
+//                switch route {
+//                case .detectSounds:
+//                 DetectSoundsView(state: appState, config: $appConfig, path: $navigationPath)
+//                }
+//            }
+//        }
+//    }
+//    
+//    private func toggleSelection(_ instrument: InstrumentType) {
+//        if selectedInstruments.contains(instrument) {
+//            selectedInstruments.remove(instrument)
+//        } else {
+//            selectedInstruments.insert(instrument)
+//        }
+//    }
+//    
+//    private func updateSelectedSounds() {
+//        appConfig.monitoredSounds = Set(selectedInstruments.map { SoundIdentifier(instrument: $0) })
+//    }
+//    
+//    private func initializeSelectedInstruments() {
+//        selectedInstruments = Set(appConfig.monitoredSounds.map { $0.instrument })
+//    }
+//}


### PR DESCRIPTION
## 🔥 작업한 내용
- 기존에 Toolbar에 표시되던 곡 제목 제거 
- 이전에 연주뷰 세팅을 위해 사용하던 `setupMonitoredSoundsView` 주석 처리
- `DetectSoundsView`에 제목 추가 
- `BandSettingView`에서 `DetectSoundsView` 초기화시 `songViewModel`을 이용 현재 선택된 곡명 전달 
- 곡명 변경시 로직 수정 


## ⭐️ PR Point
- setupMonitoredSoundsView`는 토글방식이외의 악기 선택방식이 필요할 때 참고가 될것 같아 삭제는 하지 않았습니다.
- `SideBarView`에서 `contextMenu`를 통해 선택한 곡에 대한 이름 변경시, 해당 노래가 현재 `seletedSong`과 같을시 해당 인스턴스에도 곡명 변경사항을 반영해주어야 `DetectSoundsView`에서 현재 선택된 곡 명을 정상적으로 출력할 수 있기 때문에 `SongViewModel`에 해당 로직을 추가했습니다. 

## 🚨 관련 이슈
- close: #60
