### PR TITLE
[Fix] 연주뷰 이탈시 마이크 입력 중지 

### DIFF
--- a/Lvlance/Lvlance/Views/Playing/DetectSoundsView.swift
+++ b/Lvlance/Lvlance/Views/Playing/DetectSoundsView.swift
@@ -101,5 +101,8 @@ struct DetectSoundsView: View {
                 }
             }
         }
+        .onDisappear{
+            SystemAudioClassifier.singleton.stopSoundClassification()
+        }
     }
 }


### PR DESCRIPTION
## 🔥 작업한 내용
- `DetectSoundsView`에서 벗어날시 소리 분류 요청을 중지했습니다. 


## ⭐️ PR Point
- 오디오 인디케이터는 audioManager로 input stream을 시작해도 실제 해당 stream을 캡쳐해서 사용하기 전까지는 들어오지 않습니다.
- 위와 같은 동작은 실제 앱 환경에서의 오디오 사용 시점을 명확히 하기 위한 동작입니다. 
- `SystemAudioClassifier.singleton.stopSoundClassification()`를 이용해 오디오 스트림 캡쳐를 중지합니다. 
- `SystemAudioClassifier`를 싱글톤으로 유지하면서 앱내에서 오디오 인풋 사용여부를 일관성있게 관리 가능합니다. 

## 🚨 관련 이슈
- Close: #65 
