### PR TITLE
[Feat] 연주뷰 뒤로가기 버튼 추가 

### DIFF
--- a/Lvlance/Lvlance.xcodeproj/project.pbxproj
+++ b/Lvlance/Lvlance.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		AFB83FAA2C5C76DA00E48896 /* InstrumentBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB83FA52C5C76DA00E48896 /* InstrumentBar.swift */; };
 		AFB83FAB2C5C76DA00E48896 /* SettingPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB83FA62C5C76DA00E48896 /* SettingPopoverView.swift */; };
 		AFF48AD02C7EE31C005D45D9 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = AFF48ACF2C7EE31C005D45D9 /* InfoPlist.xcstrings */; };
+		AFF48BD02C874105005D45D9 /* QuitPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48BCF2C874105005D45D9 /* QuitPopoverView.swift */; };
 		B57DBED52C4E78D600E8F182 /* MicSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57DBED42C4E78D600E8F182 /* MicSelectView.swift */; };
 		B57DBED72C4E78E400E8F182 /* BandSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57DBED62C4E78E400E8F182 /* BandSettingView.swift */; };
 		B57DBED92C4E78FF00E8F182 /* SideBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57DBED82C4E78FF00E8F182 /* SideBarView.swift */; };
@@ -60,6 +61,7 @@
 		AFB83FA52C5C76DA00E48896 /* InstrumentBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstrumentBar.swift; sourceTree = "<group>"; };
 		AFB83FA62C5C76DA00E48896 /* SettingPopoverView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingPopoverView.swift; sourceTree = "<group>"; };
 		AFF48ACF2C7EE31C005D45D9 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		AFF48BCF2C874105005D45D9 /* QuitPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitPopoverView.swift; sourceTree = "<group>"; };
 		B57DBED42C4E78D600E8F182 /* MicSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicSelectView.swift; sourceTree = "<group>"; };
 		B57DBED62C4E78E400E8F182 /* BandSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandSettingView.swift; sourceTree = "<group>"; };
 		B57DBED82C4E78FF00E8F182 /* SideBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarView.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				AFB83FA52C5C76DA00E48896 /* InstrumentBar.swift */,
 				AFB83FA62C5C76DA00E48896 /* SettingPopoverView.swift */,
 				AFB83FA42C5C76DA00E48896 /* SetupMonitoredSoundView.swift */,
+				AFF48BCF2C874105005D45D9 /* QuitPopoverView.swift */,
 			);
 			path = Playing;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				AFB83FAA2C5C76DA00E48896 /* InstrumentBar.swift in Sources */,
 				C73C83852C5A299B001B7540 /* OnboardingStartView.swift in Sources */,
 				C7D8AC992C5B890E001AB123 /* Device.swift in Sources */,
+				AFF48BD02C874105005D45D9 /* QuitPopoverView.swift in Sources */,
 				AFB83FAB2C5C76DA00E48896 /* SettingPopoverView.swift in Sources */,
 				AF11F9F12C57E2300009E685 /* SystemAudioClassifier.swift in Sources */,
 				B5C9B47D2C61014500FE4F81 /* SongViewModel.swift in Sources */,

--- a/Lvlance/Lvlance/Localizable.xcstrings
+++ b/Lvlance/Lvlance/Localizable.xcstrings
@@ -273,6 +273,9 @@
         }
       }
     },
+    "연주를 완료하고 이전 화면으로 이동하시겠어요?" : {
+
+    },
     "완료" : {
       "localizations" : {
         "en" : {
@@ -312,6 +315,9 @@
           }
         }
       }
+    },
+    "이동하기" : {
+
     },
     "일렉" : {
       "localizations" : {
@@ -394,6 +400,7 @@
       }
     },
     "탐지할 악기 선택" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Lvlance/Lvlance/Views/Playing/DetectSoundsView.swift
+++ b/Lvlance/Lvlance/Views/Playing/DetectSoundsView.swift
@@ -16,7 +16,8 @@ struct DetectSoundsView: View {
     @Binding var config: AppConfiguration
     @Binding var path: NavigationPath
     @State private var isLoading = false
-    var songTitle: String 
+    @State var isQuit = false
+    var songTitle: String
     
     static func generateMeter(confidence: Double, width: CGFloat, height: CGFloat, varientSize: Double) -> some View {
         GeometryReader { geometry in
@@ -86,11 +87,29 @@ struct DetectSoundsView: View {
         }
         .overlay(alignment: .topLeading){
             Text(songTitle)
-                .font(.system(size: 18))
+                .font(.system(size: 16))
                 .fontWeight(.semibold)
                 .padding(.leading, 60)
                 .padding(.top, 60)
         }
+        .overlay(alignment: .bottomTrailing){
+            Text("완료")
+                .font(.system(size: 16))
+                .fontWeight(.regular)
+                .padding(.vertical, 3)
+                .padding(.horizontal, 6)
+                .background(.systemPurple , in: .rect(cornerRadius: 4))
+                .padding(.trailing, 60)
+                .padding(.bottom, 60)
+                .onTapGesture {
+                    isQuit = true
+                }
+                .popover(isPresented: $isQuit) {
+                    QuitPopoverView(path: $path)
+                }
+                
+        }
+        
         .onDisappear{
             SystemAudioClassifier.singleton.stopSoundClassification()
         }

--- a/Lvlance/Lvlance/Views/Playing/QuitPopoverView.swift
+++ b/Lvlance/Lvlance/Views/Playing/QuitPopoverView.swift
@@ -1,0 +1,33 @@
+//
+//  QuitPopoverView.swift
+//  Lvlance
+//
+//  Created by 이종선 on 9/3/24.
+//
+
+import SwiftUI
+
+struct QuitPopoverView: View {
+    
+    @Binding var path: NavigationPath
+    
+    var body: some View {
+        VStack(alignment:.center){
+            Text("연주를 완료하고 이전 화면으로 이동하시겠어요?")
+            
+            Text("이동하기")
+                .padding()
+                .background{
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(.systemPurple)
+                        .frame(width: 160, height: 30)
+                }
+                .onTapGesture {
+                    path.removeLast()
+                }
+                
+        }
+        .frame(minWidth: 320, minHeight: 90)
+        .padding()
+    }
+}


### PR DESCRIPTION
## 🔥 작업한 내용
### `QuitPopOverView` 추가
- `DetectedSoundsView` 로부터 `path`를 바인딩하여 이동하기 버튼을 누를시 `DetectedSoundView`를 네비게이션스택에서 제거합니다. 
### `popover` 버튼 추가 
- `popover`수정자를 이용, `isQuit` 프로퍼티를 이용해 `QuitPopoverview`의 등장여부를 결정합니다.  

## 🚨 관련 이슈
- Close: #67
