### PR TITLE
[Fix] 온보딩뷰 로직 수정 

### DIFF
--- a/Lvlance/Lvlance/LvlanceApp.swift
+++ b/Lvlance/Lvlance/LvlanceApp.swift
@@ -11,22 +11,45 @@ import SwiftUI
 struct LvlanceApp: App { 
     
     @StateObject var audioManager = AudioManager()
-    //    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
-    @State private var hasSeenOnboarding = false
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
+    //@State private var hasSeenOnboarding = false
+    @State private var isShowOnboarding = false
+    @State var isShowingMicrophoneSelector = false
+    
+    init() {
+         #if DEBUG
+         // 개발 중에는 AppStorage 값을 초기화
+         UserDefaults.standard.removeObject(forKey: "hasSeenOnboarding")
+         #endif
+     }
     
     var body: some Scene {
         WindowGroup {
-            if hasSeenOnboarding {
-                BandSettingView()
-                    .preferredColorScheme(.dark)
-                    
-            } else {
-                OnboardingView(hasSeenOnboarding: $hasSeenOnboarding)
-                    .preferredColorScheme(.dark)
-                    .fixedSize(horizontal: true, vertical: true)
-            }
+            BandSettingView()
+                .preferredColorScheme(.dark)
+                .onAppear{
+                    if !hasSeenOnboarding {
+                        isShowOnboarding = true
+                    } else {
+                        showMicrophoneSelector()
+                    }
+                }
+                .sheet(isPresented: $isShowOnboarding, onDismiss: {
+                    showMicrophoneSelector()
+                }, content: {
+                    OnboardingView(isShowOnboarding: $isShowOnboarding)
+                })
+                .sheet(isPresented: $isShowingMicrophoneSelector, content: {
+                    MicSelectView(isShowingMicrophoneSelector: $isShowingMicrophoneSelector)
+                })
         }
         .environmentObject(audioManager)
-        .windowResizability(!hasSeenOnboarding ? .contentSize : .automatic)
+    }
+    
+    private func showMicrophoneSelector() {
+        isShowingMicrophoneSelector = true
+        Task {
+            await audioManager.start()
+        }
     }
 }

--- a/Lvlance/Lvlance/Views/BandSetting/BandSettingView.swift
+++ b/Lvlance/Lvlance/Views/BandSetting/BandSettingView.swift
@@ -8,10 +8,9 @@
 import SwiftUI
 
 struct BandSettingView: View {
-    @EnvironmentObject var audioManager: AudioManager
+    
     @StateObject var songViewModel = SongViewModel()
     
-    @State var isShowingMicrophoneSelector = false
     @State private var isAddingPresented = false
     @State private var isEditingPresented = false
     
@@ -44,20 +43,11 @@ struct BandSettingView: View {
             }
         }
         .frame(minWidth: 1510, minHeight: 834)
-        .sheet(isPresented: $isShowingMicrophoneSelector, content: {
-            MicSelectView(isShowingMicrophoneSelector: $isShowingMicrophoneSelector)
-        })
         .sheet(isPresented: $isEditingPresented, content: {
             InstrumentAddingView(songViewModel: songViewModel, isSheetPresented: $isEditingPresented, isEdit: true)
         })
         .sheet(isPresented: $isAddingPresented, content: {
             InstrumentAddingView(songViewModel: songViewModel, isSheetPresented: $isAddingPresented)
         })
-        .onAppear {
-            isShowingMicrophoneSelector = true
-            Task {
-                await audioManager.start()
-            }
-        }
     }
 }

--- a/Lvlance/Lvlance/Views/Onboardiing/OnboardingView.swift
+++ b/Lvlance/Lvlance/Views/Onboardiing/OnboardingView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct OnboardingView: View {
     @State private var currentStep = 0
-    @Binding var hasSeenOnboarding: Bool
+    @Binding var isShowOnboarding: Bool
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
     
     var body: some View {
         VStack {
@@ -47,6 +48,7 @@ struct OnboardingView: View {
                     action: {
                         currentStep += 1
                         hasSeenOnboarding = true
+                        isShowOnboarding = false
                     }
                 )
             default:


### PR DESCRIPTION
## 🔥 작업한 내용
- 기존에 별도의 윈도우를 활용하여 온보딩뷰를 구성하던 방식을 Sheet로 변경했습니다. 
- `MicSelectorView`를 온보딩뷰 Sheet와 같은 계층으로 구성했습니다. 
- `sheet`의 dismiss 클로저를 활용해 온보딩뷰가 뜬 경우에도 `MicSelectorView`를 이용해 마이크 설정이 가능하도록 했습니다. 
- 디버그 플래그를 이용해 빌드시 `@AppStorage`를 초기화해 확인할 수 있도록 했습니다. 

## ⭐️ PR Point
- 같은 View 위에 있는 sheet가 계층이 나뉜 경우, 첫번째 sheet가 내려가도 해당 자리에 sheet의 흔적?이 남습니다. 
- 온보딩뷰를 Sheet 방식으로 바꾸었습니다. 
- 커밋에 이슈 번호를 잘못 적었습니다. 68 X -> 47 O
## 🚨 관련 이슈
- Close: #47 
