### PR TITLE
[Hotfix] microphone key 명시적 추가

### DIFF
--- a/Lvlance/Lvlance/Lvlance.entitlements
+++ b/Lvlance/Lvlance/Lvlance.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+    <key>com.apple.security.device.microphone</key>
+    <true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 </dict>


### PR DESCRIPTION
## 🔥 작업한 내용
- Entitlement에 reviewer가 요구한 "com.apple.security.device.microphone"를 추가했습니다.


## ⭐️ PR Point
현재 Capability Tab에서 Sandbox 항목에 Audio Input을 추가해서마이크 입력 사용에 필요한 권한을 이미 명시를 했는데 왜 추가적인 key 값을 요구하는지 모르겠지만 일단은 reviewer의 요구대로 추가했습니다. 


## 📸 스크린샷
![스크린샷 2024-09-07 시간: 12 54 25](https://github.com/user-attachments/assets/092be4a6-6deb-4cb3-add0-ae6764746ab5)

## 🚨 관련 이슈
- close: #79 

